### PR TITLE
DM-43675: Stop using quote syntax in messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.2.1'></a>
+## 0.2.1 (2024-04-03)
+
+### Bug fixes
+
+- Stop using the mrkdwn quote in the main unfurled content because it down't present well in mobile views.
+
 <a id='changelog-0.2.0'></a>
 ## 0.2.0 (2024-03-04)
 

--- a/changelog.d/20240403_184036_jsick_DM_43675.md
+++ b/changelog.d/20240403_184036_jsick_DM_43675.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Stop using the mrkdwn quote in the main unfurled content because it down't present well in mobile views.

--- a/changelog.d/20240403_184036_jsick_DM_43675.md
+++ b/changelog.d/20240403_184036_jsick_DM_43675.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- Stop using the mrkdwn quote in the main unfurled content because it down't present well in mobile views.

--- a/src/unfurlbot/services/jiraunfurler.py
+++ b/src/unfurlbot/services/jiraunfurler.py
@@ -153,7 +153,7 @@ class JiraUnfurler(DomainUnfurler):
 
         # The main section block
         main_block = SlackTextSectionBlock(
-            text=(f"> <{issue.homepage}|*{issue.key}*> {issue.summary}"),
+            text=(f"<{issue.homepage}|*{issue.key}*> {issue.summary}"),
             fields=[],
         )
 


### PR DESCRIPTION
The original intent of the mrkdwn quote was to emulate the attachments API's ability to add a coloured bar to content blocks. We don't want to use attachments because the API is technically deprecated. However, we've also found that the mrkdwn quote wraps poorly on Slack mobile views and has done so for many months now and is unlikely to be fixed upstream. To mitigate this we'll simply remove the quote from unfurlbot's messages.