### PR TITLE
DM-45917: Publish asyncapi docs to /asyncapi

### DIFF
--- a/src/unfurlbot/handlers/kafka.py
+++ b/src/unfurlbot/handlers/kafka.py
@@ -23,6 +23,7 @@ kafka_security = BaseSecurity(ssl_context=config.kafka.ssl_context)
 kafka_router = KafkaRouter(
     config.kafka.bootstrap_servers,
     security=kafka_security,
+    schema_url=f"{config.path_prefix}/asyncapi",
     logger=get_logger(__name__),
 )
 


### PR DESCRIPTION
This configures FastStream to publish the asyncapi docs to `/unfurlbot/asyncapi` and the JSON asyncapi schema is published to `/unfurlbot/asyncapi.json`.