### PR TITLE
DM-47672: Require Jira tickets start at a word boundary

### DIFF
--- a/changelog.d/20241202_143730_rra_DM_47672.md
+++ b/changelog.d/20241202_143730_rra_DM_47672.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Require Jira ticket references start at a word boundary so that, for example, `LDM-1234` is not detected as ticket `DM-1234`.

--- a/src/unfurlbot/services/jiraunfurler.py
+++ b/src/unfurlbot/services/jiraunfurler.py
@@ -122,7 +122,7 @@ class JiraUnfurler(DomainUnfurler):
         text = re.sub(r"https?://\S+", "", text)
 
         projects = await self.get_projects()
-        key_pattern = rf"((?:{'|'.join(projects)})-\d+)"
+        key_pattern = rf"\b((?:{'|'.join(projects)})-\d+)"
         matches = re.findall(key_pattern, text)
         matches = list({str(m) for m in matches})  # Deduplicate
         return sorted(matches)

--- a/tests/services/jiraunfurler_test.py
+++ b/tests/services/jiraunfurler_test.py
@@ -35,4 +35,9 @@ async def test_key_extraction() -> None:
     keys = await jira_unfurler.extract_issues(text)
     assert keys == ["DM-1234"]
 
+    # Test that prefixes cause the tickets to not be recognized.
+    text = "Some discussion LDM-1234 other stuff DM-5678 blah"
+    keys = await jira_unfurler.extract_issues(text)
+    assert keys == ["DM-5678"]
+
     await process_contact.aclose()


### PR DESCRIPTION
Require Jira ticket references start at a word boundary so that, for example, `LDM-1234` is not detected as ticket `DM-1234`.