### PR TITLE
DM-47672: Switch to uv for Docker container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,27 @@
-# This Dockerfile has four stages:
+# This Dockerfile has three stages:
 #
 # base-image
 #   Updates the base Python image with security patches and common system
 #   packages. This image becomes the base of all other images.
-# dependencies-image
-#   Installs third-party dependencies (requirements/main.txt) into a virtual
-#   environment. This virtual environment is ideal for copying across build
-#   stages.
 # install-image
-#   Installs the app into the virtual environment.
+#   Installs third-party dependencies (requirements/main.txt) and the
+#   application into a virtual environment. This virtual environment is ideal
+#   for copying across build stages.
 # runtime-image
 #   - Copies the virtual environment into place.
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.12.6-slim-bookworm AS base-image
+FROM python:3.12.7-slim-bookworm AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
 RUN ./install-base-packages.sh && rm ./install-base-packages.sh
 
-FROM base-image AS dependencies-image
+FROM base-image AS install-image
+
+# Install uv.
+COPY --from=ghcr.io/astral-sh/uv:0.5.5 /uv /bin/uv
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
@@ -28,24 +29,20 @@ RUN ./install-dependency-packages.sh
 
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv
-RUN python -m venv $VIRTUAL_ENV
+RUN uv venv $VIRTUAL_ENV
+
 # Make sure we use the virtualenv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-# Put the latest pip and setuptools in the virtualenv
-RUN pip install --upgrade --no-cache-dir pip setuptools wheel
 
 # Install the app's Python runtime dependencies
 COPY requirements/main.txt ./requirements.txt
-RUN pip install --quiet --no-cache-dir -r requirements.txt
+RUN uv pip install --compile-bytecode --verify-hashes --no-cache \
+    -r requirements.txt
 
-FROM dependencies-image AS install-image
-
-# Use the virtualenv
-ENV PATH="/opt/venv/bin:$PATH"
-
+# Install the application itself.
 COPY . /workdir
 WORKDIR /workdir
-RUN pip install --no-cache-dir .
+RUN uv pip install --compile-bytecode --no-cache .
 
 FROM base-image AS runtime-image
 


### PR DESCRIPTION
Use uv to install Python dependencies and the application into the Docker container, and switch to a three-stage Docker build matching the current FastAPI Safir app template.