### PR TITLE
DM-47672: Use Safir mechanism for Kafka configuration

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -13,8 +13,8 @@ starlette
 uvicorn[standard]
 
 # Other dependencies.
-pydantic
+pydantic>2
 pydantic-settings
-safir[redis]>=5
+safir[redis]>=6.5.0
 faststream[kafka]
 rubin-squarebot>=0.8.0

--- a/src/unfurlbot/config.py
+++ b/src/unfurlbot/config.py
@@ -2,207 +2,20 @@
 
 from __future__ import annotations
 
-import ssl
-from enum import Enum
-from pathlib import Path
-
-from pydantic import (
-    DirectoryPath,
-    Field,
-    FilePath,
-    RedisDsn,
-    SecretStr,
-    field_validator,
-)
+from pydantic import Field, RedisDsn, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from safir.kafka import KafkaConnectionSettings
 from safir.logging import LogLevel, Profile
 
 __all__ = ["Config", "config"]
 
 
-class KafkaSecurityProtocol(str, Enum):
-    """Kafka security protocols understood by aiokafka."""
-
-    PLAINTEXT = "PLAINTEXT"
-    """Plain-text connection."""
-
-    SSL = "SSL"
-    """TLS-encrypted connection."""
-
-
-class KafkaSaslMechanism(str, Enum):
-    """Kafka SASL mechanisms understood by aiokafka."""
-
-    PLAIN = "PLAIN"
-    """Plain-text SASL mechanism."""
-
-    SCRAM_SHA_256 = "SCRAM-SHA-256"
-    """SCRAM-SHA-256 SASL mechanism."""
-
-    SCRAM_SHA_512 = "SCRAM-SHA-512"
-    """SCRAM-SHA-512 SASL mechanism."""
-
-
-class KafkaConnectionSettings(BaseSettings):
-    """Settings for connecting to Kafka."""
-
-    bootstrap_servers: str = Field(
-        ...,
-        title="Kafka bootstrap servers",
-        description=(
-            "A comma-separated list of Kafka brokers to connect to. "
-            "This should be a list of hostnames or IP addresses, "
-            "each optionally followed by a port number, separated by "
-            "commas. "
-            "For example: `kafka-1:9092,kafka-2:9092,kafka-3:9092`."
-        ),
-    )
-
-    security_protocol: KafkaSecurityProtocol = Field(
-        KafkaSecurityProtocol.PLAINTEXT,
-        description="The security protocol to use when connecting to Kafka.",
-    )
-
-    cert_temp_dir: DirectoryPath | None = Field(
-        None,
-        description=(
-            "Temporary writable directory for concatenating certificates."
-        ),
-    )
-
-    cluster_ca_path: FilePath | None = Field(
-        None,
-        title="Path to CA certificate file",
-        description=(
-            "The path to the CA certificate file to use for verifying the "
-            "broker's certificate. "
-            "This is only needed if the broker's certificate is not signed "
-            "by a CA trusted by the operating system."
-        ),
-    )
-
-    client_ca_path: FilePath | None = Field(
-        None,
-        title="Path to client CA certificate file",
-        description=(
-            "The path to the client CA certificate file to use for "
-            "authentication. "
-            "This is only needed when the client certificate needs to be"
-            "concatenated with the client CA certificate, which is common"
-            "for Strimzi installations."
-        ),
-    )
-
-    client_cert_path: FilePath | None = Field(
-        None,
-        title="Path to client certificate file",
-        description=(
-            "The path to the client certificate file to use for "
-            "authentication. "
-            "This is only needed if the broker is configured to require "
-            "SSL client authentication."
-        ),
-    )
-
-    client_key_path: FilePath | None = Field(
-        None,
-        title="Path to client key file",
-        description=(
-            "The path to the client key file to use for authentication. "
-            "This is only needed if the broker is configured to require "
-            "SSL client authentication."
-        ),
-    )
-
-    client_key_password: SecretStr | None = Field(
-        None,
-        title="Password for client key file",
-        description=(
-            "The password to use for decrypting the client key file. "
-            "This is only needed if the client key file is encrypted."
-        ),
-    )
-
-    sasl_mechanism: KafkaSaslMechanism | None = Field(
-        KafkaSaslMechanism.PLAIN,
-        title="SASL mechanism",
-        description=(
-            "The SASL mechanism to use for authentication. "
-            "This is only needed if SASL authentication is enabled."
-        ),
-    )
-
-    sasl_username: str | None = Field(
-        None,
-        title="SASL username",
-        description=(
-            "The username to use for SASL authentication. "
-            "This is only needed if SASL authentication is enabled."
-        ),
-    )
-
-    sasl_password: SecretStr | None = Field(
-        None,
-        title="SASL password",
-        description=(
-            "The password to use for SASL authentication. "
-            "This is only needed if SASL authentication is enabled."
-        ),
-    )
-
-    model_config = SettingsConfigDict(
-        env_prefix="KAFKA_",
-        case_sensitive=False,
-    )
-
-    @property
-    def ssl_context(self) -> ssl.SSLContext | None:
-        """An SSL context for connecting to Kafka with aiokafka, if the
-        Kafka connection is configured to use SSL.
-        """
-        if (
-            self.security_protocol != KafkaSecurityProtocol.SSL
-            or self.cluster_ca_path is None
-            or self.client_cert_path is None
-            or self.client_key_path is None
-        ):
-            return None
-
-        client_cert_path = Path(self.client_cert_path)
-
-        if self.client_ca_path is not None:
-            # Need to contatenate the client cert and CA certificates. This is
-            # typical for Strimzi-based Kafka clusters.
-            if self.cert_temp_dir is None:
-                raise RuntimeError(
-                    "KAFKIT_KAFKA_CERT_TEMP_DIR must be set when "
-                    "a client CA certificate is provided.",
-                )
-            client_ca = Path(self.client_ca_path).read_text()
-            client_cert = Path(self.client_cert_path).read_text()
-            sep = "" if client_ca.endswith("\n") else "\n"
-            new_client_cert = sep.join([client_cert, client_ca])
-            new_client_cert_path = Path(self.cert_temp_dir) / "client.crt"
-            new_client_cert_path.write_text(new_client_cert)
-            client_cert_path = Path(new_client_cert_path)
-
-        # Create an SSL context on the basis that we're the client
-        # authenticating the server (the Kafka broker).
-        ssl_context = ssl.create_default_context(
-            purpose=ssl.Purpose.SERVER_AUTH,
-            cafile=str(self.cluster_ca_path),
-        )
-        # Add the certificates that the Kafka broker uses to authenticate us.
-        ssl_context.load_cert_chain(
-            certfile=str(client_cert_path),
-            keyfile=str(self.client_key_path),
-        )
-
-        return ssl_context
-
-
 class Config(BaseSettings):
     """Configuration for unfurlbot."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="UNFURLBOT_", case_sensitive=False
+    )
 
     name: str = Field("unfurlbot", title="Name of application")
 
@@ -344,11 +157,6 @@ class Config(BaseSettings):
         title="interaction Kafka topic",
         alias="UNFURLBOT_TOPIC_INTERACTION",
         description=("Kafka topic name for `interaction` Slack events"),
-    )
-
-    model_config = SettingsConfigDict(
-        env_prefix="UNFURLBOT_",
-        case_sensitive=False,
     )
 
     @property

--- a/src/unfurlbot/handlers/kafka.py
+++ b/src/unfurlbot/handlers/kafka.py
@@ -4,7 +4,6 @@ from typing import Annotated
 
 from fastapi import Depends
 from faststream.kafka.fastapi import KafkaRouter
-from faststream.security import BaseSecurity
 from rubin.squarebot.models.kafka import SquarebotSlackMessageValue
 from structlog import get_logger
 
@@ -17,11 +16,8 @@ from ..dependencies.consumercontext import (
 __all__ = ["handle_slack_message", "kafka_router"]
 
 
-kafka_security = BaseSecurity(ssl_context=config.kafka.ssl_context)
 kafka_router = KafkaRouter(
-    config.kafka.bootstrap_servers,
-    security=kafka_security,
-    logger=get_logger(__name__),
+    **config.kafka.to_faststream_params(), logger=get_logger(__name__)
 )
 
 


### PR DESCRIPTION
Replace the Kafka configuration with `KafkaConnectionSettings` from `safir.kafka`, and bump the dependency on Safir accordingly.