### PR TITLE
DM-47974: Allow configuration of Jira request timeout

### DIFF
--- a/changelog.d/20241205_124257_rra_DM_47974.md
+++ b/changelog.d/20241205_124257_rra_DM_47974.md
@@ -1,0 +1,3 @@
+### New features
+
+- Allow configuration of the timeout when making requests to the Jira server instead of only using the 20s default.

--- a/src/unfurlbot/config.py
+++ b/src/unfurlbot/config.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from pydantic import Field, RedisDsn, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.kafka import KafkaConnectionSettings
 from safir.logging import LogLevel, Profile
+from safir.pydantic import HumanTimedelta
 
 __all__ = ["Config", "config"]
 
@@ -88,6 +91,13 @@ class Config(BaseSettings):
             "A comma-separated list of Jira issue keys to recognize in "
             "messages."
         ),
+    )
+
+    jira_timeout: HumanTimedelta = Field(
+        timedelta(seconds=20),
+        title="Jira request timeout",
+        description="How long to wait for a response from the Jira server.",
+        examples=["60s"],
     )
 
     gafaelfawr_token: SecretStr = Field(

--- a/src/unfurlbot/storage/jiraissues.py
+++ b/src/unfurlbot/storage/jiraissues.py
@@ -50,6 +50,7 @@ class JiraIssueClient:
         response = await self._http_client.get(
             f"{self._proxy_base}{path}",
             headers={"Authorization": f"Bearer {self._token}"},
+            timeout=config.jira_timeout.total_seconds(),
         )
         response.raise_for_status()  # add a proper error message
         return response.json()


### PR DESCRIPTION
We saw several unfurl failures due to Jira request timeouts. Make the timeout configurable instead of using the 20s default from Safir.