### PR TITLE
DM-51754: Run CI Docker build (no push) for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,13 +62,19 @@ jobs:
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ghcr.io/${{ github.repository }}
+      # Build but don't push for dependabot PRs: no registry secrets are
+      # available and we don't want dependency-bump images in the registry.
+      push: >-
+        ${{ (github.event_name == 'release' && github.event.action == 'published')
+            || startsWith(github.head_ref, 'tickets/') }}
 
-    # Only do Docker builds of tagged releases and pull requests from ticket
-    # branches.  This will still trigger on pull requests from untrusted
-    # repositories whose branch names match our tickets/* branch convention,
-    # but in this case the build will fail with an error since the secret
-    # won't be set.
+    # Build on releases, ticket-branch PRs (build + push), and dependabot PRs
+    # (build only) so the required "build / manifest" check is reported.
+    # This will still trigger on pull requests from untrusted repositories
+    # whose branch names match our tickets/* branch convention, but in this
+    # case the push will fail with an error since the secret won't be set.
     if: >
       (github.event_name == 'release' && github.event.action == 'published')
       || (github.event_name != 'merge_group'
-          && startsWith(github.head_ref, 'tickets/'))
+          && (startsWith(github.head_ref, 'tickets/')
+              || startsWith(github.head_ref, 'dependabot/')))

--- a/changelog.d/20260622_000000_jsick_DM_51754.md
+++ b/changelog.d/20260622_000000_jsick_DM_51754.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- The CI `build` job now also runs for Dependabot pull requests, building the Docker image for both `linux/amd64` and `linux/arm64` without pushing it. This reports the required `build / manifest` status check (as a passing `skipped` conclusion) so Dependabot PRs can satisfy the `main` branch ruleset and auto-merge. Release and ticket-branch builds are unchanged and still push images.


### PR DESCRIPTION
## Summary

- Extend the `ci.yaml` `build` job to also run for `dependabot/**` head branches, building the Docker image on both `linux/amd64` and `linux/arm64` without pushing it.
- Pass `push:` to the reusable build workflow as an expression that is `true` only for tagged releases and `tickets/**` branches, so the gated `manifest` job is skipped (reporting a passing `skipped` conclusion) on dependabot PRs — satisfying the required `build / manifest` check so dependabot PRs can auto-merge under the `main` ruleset.

## Validation steps

- On a `dependabot/**` PR, confirm `build / containers` builds the Dockerfile on both arches and `build / manifest` reports `skipped` (passing), with no image pushed to the registry.
- On a `tickets/**` PR (e.g. this one), confirm `build / manifest` still runs and builds + pushes as before.
- Confirm a tagged release still builds and pushes images unchanged.

## References

- Closes #31
- PRD: #23
- Jira: https://rubinobs.atlassian.net/browse/DM-51754