### PR TITLE
DM-55493: Ruff configured via shared ruff-shared.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ python_files = ["tests/*.py", "tests/*/*.py"]
 # section for project-specific ignore rules.
 [tool.ruff]
 extend = "ruff-shared.toml"
+target-version = "py314"
 
 [tool.ruff.lint.isort]
 known-first-party = ["unfurlbot", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ target-version = "py314"
 
 [tool.ruff.lint.isort]
 known-first-party = ["unfurlbot", "tests"]
-split-on-trailing-comma = false
 
 [tool.scriv]
 categories = [

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -20,7 +20,6 @@
 # Reference for rules: https://docs.astral.sh/ruff/rules/
 exclude = ["docs/**"]
 line-length = 79
-target-version = "py314"
 
 [format]
 docstring-code-format = true
@@ -147,6 +146,9 @@ builtins-ignorelist = [
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
+
+[lint.isort]
+split-on-trailing-comma = false
 
 [lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
Refreshes the vendored `ruff-shared.toml` with the current canonical copy from [lsst/templates](https://github.com/lsst/templates) (`project_templates/fastapi_safir_app/{{cookiecutter.name}}/ruff-shared.toml`).

- Overwrote `ruff-shared.toml` with the canonical template copy.
- Moved the repo-specific `target-version = "py314"` setting (not part of the canonical shared config) to `pyproject.toml`'s `[tool.ruff]` section so it isn't lost.
- `ruff check .` and `ruff format --check .` both pass cleanly with the refreshed ruleset — no new findings, no formatting changes needed.

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ