### PR TITLE
DM-55493: collect changelog for 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.5.2'></a>
+## 0.5.2 (2026-07-20)
+
+### Other changes
+
+- The CI `build` job now also runs for Dependabot pull requests, building the Docker image for both `linux/amd64` and `linux/arm64` without pushing it. This reports the required `build / manifest` status check (as a passing `skipped` conclusion) so Dependabot PRs can satisfy the `main` branch ruleset and auto-merge. Release and ticket-branch builds are unchanged and still push images.
+
+- Update pinned dependencies and pre-commit hooks.
+
 <a id='changelog-0.5.1'></a>
 ## 0.5.1 (2026-06-19)
 

--- a/changelog.d/20260622_000000_jsick_DM_51754.md
+++ b/changelog.d/20260622_000000_jsick_DM_51754.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- The CI `build` job now also runs for Dependabot pull requests, building the Docker image for both `linux/amd64` and `linux/arm64` without pushing it. This reports the required `build / manifest` status check (as a passing `skipped` conclusion) so Dependabot PRs can satisfy the `main` branch ruleset and auto-merge. Release and ticket-branch builds are unchanged and still push images.

--- a/changelog.d/20260720_101901_jonathan_DM_55493_update.md
+++ b/changelog.d/20260720_101901_jonathan_DM_55493_update.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Update pinned dependencies and pre-commit hooks.


### PR DESCRIPTION
## Summary
- Collects the `changelog.d/` fragments into a new `0.5.2` entry in CHANGELOG.md ahead of release.
- Fragments released: the dependency-refresh line from the DM-55493 monthly update, plus a pre-existing unreleased fragment (DM-51754, CI build job for Dependabot PRs) that had been waiting in `changelog.d/`.
- `_template.md.jinja` is untouched.

## Jira
[DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

## Test plan
- [ ] Confirm CHANGELOG.md 0.5.2 entry reads correctly
- [ ] Merge and tag `0.5.2` as a separate release step (not part of this PR)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ